### PR TITLE
Create appium utils, fix for blocked ports and sample of data provider

### DIFF
--- a/src/main/java/com/mobileframework/pageObjects/android/InitialPage.java
+++ b/src/main/java/com/mobileframework/pageObjects/android/InitialPage.java
@@ -1,5 +1,7 @@
 package com.mobileframework.pageObjects.android;
 
+import java.util.List;
+
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.PageFactory;
 
@@ -40,6 +42,9 @@ public class InitialPage extends AndroidActions {	//extends android actions to i
 
 	@AndroidFindBy(xpath = "//*[@text='Views']")
 	private WebElement viewButton;
+	
+	@AndroidFindBy(xpath = "//android.widget.EditText")
+	private List<WebElement> TextFields;
 
 	// ******Action Methods***********
 	public void clickPreferenceButton() {
@@ -48,6 +53,13 @@ public class InitialPage extends AndroidActions {	//extends android actions to i
 
 	public void clickViewButton() {
 		viewButton.click();
+	}
+	
+	public void typeTextFields(int fieldnum, String text) {
+		
+		int totalFields = TextFields.size();
+		System.out.println("Total Fields "+totalFields);
+		TextFields.get(fieldnum).sendKeys(text);;
 	}
 
 }

--- a/src/main/java/com/mobileframework/utils/AndroidActions.java
+++ b/src/main/java/com/mobileframework/utils/AndroidActions.java
@@ -9,11 +9,13 @@ import org.openqa.selenium.WebElement;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.AppiumDriver;
 
-public class AndroidActions {
+public class AndroidActions extends AppiumUtils{
 	
 	AppiumDriver driver;
 	
 	public AndroidActions(AppiumDriver driver){
+		super(driver);/*now the parent class is AppiumUtils need to refer
+		to the driver from this class*/
 		this.driver = driver;
 	}
 	

--- a/src/main/java/com/mobileframework/utils/AppiumUtils.java
+++ b/src/main/java/com/mobileframework/utils/AppiumUtils.java
@@ -1,0 +1,38 @@
+package com.mobileframework.utils;
+
+import java.time.Duration;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import io.appium.java_client.AppiumDriver;
+
+public class AppiumUtils {
+	
+	
+	//***********
+		AppiumDriver driver;//This is a global variable which will be initialize on constructor
+		
+		//Create constructor of the class sent IOSDriver as parameter 
+		//to initialize driver when class is instaciated
+		public AppiumUtils(AppiumDriver driver){
+			this.driver = driver;//This refer to class variable 'driver'  
+		}
+	
+	public Double getFormattedAmount(String amount){
+		Double price = Double.parseDouble(amount.substring(1));
+		System.out.println(price);
+		return price;
+	}
+	
+	public void waitForElement(WebElement element){	
+		WebDriverWait wait = new WebDriverWait(driver,Duration.ofSeconds(20));
+		wait.until(ExpectedConditions.elementToBeClickable(element));		
+	}
+	
+	//Wait until element is present as maximum 10 second and stored as a WebElement
+		
+	
+	
+}

--- a/src/main/java/com/mobileframework/utils/IOSActions.java
+++ b/src/main/java/com/mobileframework/utils/IOSActions.java
@@ -11,11 +11,13 @@ import com.google.common.collect.ImmutableMap;
 
 import io.appium.java_client.AppiumDriver;
 
-public class IOSActions {
+public class IOSActions extends AppiumUtils {
 	
 	AppiumDriver driver;
 	
 	public IOSActions(AppiumDriver driver){
+		super(driver);/*now the parent class is AppiumUtils need to refer
+		to the driver from this class*/
 		this.driver = driver;
 	}
 	

--- a/src/test/java/com/mobileframework/DataProviderTests.java
+++ b/src/test/java/com/mobileframework/DataProviderTests.java
@@ -1,0 +1,56 @@
+package com.mobileframework;
+
+import org.testng.annotations.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+
+import com.mobileframework.TestUtils.BaseClass1;
+import com.mobileframework.pageObjects.android.InitialPage;
+
+import io.appium.java_client.android.Activity;
+import io.appium.java_client.android.StartsActivity;
+
+public class DataProviderTests extends BaseClass1 {
+	
+		InitialPage initialPage;
+		
+		
+		
+		@BeforeMethod
+		public void presetup(){
+			Activity activity = new Activity("io.appium.android.apis","io.appium.android.apis.ApiDemos");
+			((StartsActivity) driver).startActivity(activity);
+			initialPage = new InitialPage(driver);
+		}
+		
+		@Test
+
+		public void nodataProviderTest() {
+
+			initialPage.clickViewButton();
+			initialPage.scrollDownToVisibleElement("TextFields");
+			initialPage.typeTextFields(0, "Gilberto");
+			initialPage.typeTextFields(1, "Tests");
+			initialPage.typeTextFields(2, "Other Test");
+		}
+		
+		@Test(dataProvider="getData")//Indicate test method will use data Provider
+
+		public void dataProviderTest(String field1, String field2, String field3) {
+
+			initialPage.clickViewButton();
+			initialPage.scrollDownToVisibleElement("TextFields");
+			initialPage.typeTextFields(0, field1);
+			initialPage.typeTextFields(1, field2);
+			initialPage.typeTextFields(2, field3);
+		}
+		
+		/*Add Data Provider annotation and create a bidimensional array
+		to store values*/
+		@DataProvider()
+		public Object getData(){
+			return new Object[][] {{"DataProvider1","DataProvider2","DataProvider3"}};
+		}
+		
+		
+}

--- a/src/test/java/com/mobileframework/NonSubsequentTest.java
+++ b/src/test/java/com/mobileframework/NonSubsequentTest.java
@@ -1,5 +1,6 @@
 package com.mobileframework;
 
+import org.testng.annotations.Test;
 import org.openqa.selenium.By;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/src/test/java/com/mobileframework/SubsequentTest.java
+++ b/src/test/java/com/mobileframework/SubsequentTest.java
@@ -1,5 +1,6 @@
 package com.mobileframework;
 
+import org.testng.annotations.Test;
 import org.openqa.selenium.By;
 import org.testng.annotations.Test;
 

--- a/src/test/java/com/mobileframework/TestUtils/BaseClass1.java
+++ b/src/test/java/com/mobileframework/TestUtils/BaseClass1.java
@@ -23,14 +23,14 @@ public class BaseClass1 {
 	//public InitialPage initialPage;//uncomment to run subsequent tests
 	
 	private String APP;
-	private static final int portNumber = 4725;
+	//private static final int portNumber = 4725;
 	// String portNumber = 4725;
 	private static final int sysport = 8101;
 
 	public AppiumDriver driver;
 	public AppiumDriverLocalService service;
 
-	String platformName = "Android";// ("Android, IOS")
+	String platformName = "IOS";// ("Android, IOS")
 	
 	/* //****For Future XML
 		String platformName= "Android";
@@ -54,9 +54,15 @@ public class BaseClass1 {
 		// Android driver, iOS Driver
 		// Appium Code>Appium Server>Mobile
 
-		AppiumDriverLocalService service = new AppiumServiceBuilder()
+		/*AppiumDriverLocalService service = new AppiumServiceBuilder()
 				.withAppiumJS(new File("/usr/local/lib/node_modules/appium/build/lib/main.js"))
 				.withIPAddress("127.0.0.1").withArgument(GeneralServerFlag.BASEPATH, "/wd/hub/").usingPort(portNumber)
+				.build();*/
+		
+		//Add anyfreePort() method to get a free port to use for appium test
+		AppiumDriverLocalService service = new AppiumServiceBuilder()
+				.withAppiumJS(new File("/usr/local/lib/node_modules/appium/build/lib/main.js"))
+				.withIPAddress("127.0.0.1").withArgument(GeneralServerFlag.BASEPATH, "/wd/hub/").usingAnyFreePort()
 				.build();
 		service.start();
 		switch (platformName) {
@@ -81,7 +87,9 @@ public class BaseClass1 {
 			//caps.setCapability(AndroidMobileCapabilityType.ADB_EXEC_TIMEOUT, 120000);
 			//caps.setCapability(MobileCapabilityType.NEW_COMMAND_TIMEOUT, 3000);
 
-			driver = new AndroidDriver(new URL("http://localhost:" + portNumber + "/wd/hub"), caps);
+			//driver = new AndroidDriver(new URL("http://localhost:" + portNumber + "/wd/hub"), caps);
+			//Build Android driver and get service url from any free port
+			driver = new AndroidDriver(service.getUrl(), caps);
 			//initialPage = new InitialPage(driver);//uncomment to run subsequent tests
 			break;
 		case "IOS":
@@ -98,7 +106,9 @@ public class BaseClass1 {
 			caps.setCapability("wdaLocalPort", sysport);
 			caps.setCapability("wdaLaunchTimeout", "30000");
 
-			driver = new IOSDriver(new URL("http://localhost:" + portNumber + "/wd/hub"), caps);
+			//driver = new IOSDriver(new URL("http://localhost:" + portNumber + "/wd/hub"), caps);
+			//Build iOS driver and get service url from any free port
+			driver = new IOSDriver(service.getUrl(), caps);
 			break;
 		default:
 			System.out.println(platformName + " Platform is not valid");

--- a/testng.xml
+++ b/testng.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="Suite">
+  <test thread-count="5" name="Test">
+    <classes>
+      <class name="com.mobileframework.SubsequentTest"/>
+      <class name="com.mobileframework.NonSubsequentTest"/>
+      <class name="com.mobileframework.InitialTests"/>
+      <class name="com.mobileframework.InitialTests_iOS"/>
+    </classes>
+  </test> <!-- Test -->
+</suite> <!-- Suite -->


### PR DESCRIPTION
-Added AppiumUtils super class to store common methods for Android and iOS now Actions classes extends AppiumUtils -Create a test with a example of how to use DataProvider method and use test data in tests. -Fix the issue to block port after running a scrypt by adding anyFreePort() method when starting appium service -Add a example testng.xml to demonstrate how to run scripts with a xml file